### PR TITLE
feat(ssl): use client certificates for auth

### DIFF
--- a/.cspell.project-words.txt
+++ b/.cspell.project-words.txt
@@ -42,3 +42,9 @@ BYDAY
 DTSTART
 RRULE
 dockerenv
+pkcs
+initdb
+microdnf
+nocrypt
+outform
+topk

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1417,7 +1417,7 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "svc-storage"
-version = "0.4.0-develop.1"
+version = "0.4.0-develop.2"
 dependencies = [
  "anyhow",
  "cargo-husky",
@@ -1447,7 +1447,7 @@ dependencies = [
 
 [[package]]
 name = "svc-storage-client-grpc"
-version = "0.4.0-develop.1"
+version = "0.4.0-develop.2"
 dependencies = [
  "prost",
  "prost-types",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,9 +19,6 @@ services:
         source: scripts/cockroachdb-init.sh
         target: /scripts/cockroachdb-init.sh
         read_only: true
-    ports:
-      - 26257:26257
-      - 8080:8080
     entrypoint: ["/bin/sh", "-c"]
     command: ["/scripts/cockroachdb-init.sh"]
 
@@ -32,6 +29,9 @@ services:
       cockroachdb-init:
         condition: service_completed_successfully
     volumes:
+      - type: bind
+        source: scripts/init.sql
+        target: /docker-entrypoint-initdb.d/init.sql
       - type: volume
         source: cockroachdb
         target: /cockroach/cockroach-data
@@ -47,7 +47,7 @@ services:
     ports:
       - 26257:26257
       - 8080:8080
-    command: start-single-node --certs-dir=/cockroach/ssl/certs
+    command: start-single-node --certs-dir=/cockroach/ssl/certs --advertise-addr=cockroachdb
 
   web-server:
     container_name: ${DOCKER_NAME}-example-server
@@ -68,13 +68,15 @@ services:
     env_file:
       - .env
     environment:
+      - RUST_BACKTRACE
       - PG__USER
       - PG__DBNAME
-      - PG__PASSWORD
       - PG__HOST
       - PG__PORT
       - PG__SSLMODE
       - DB_CA_CERT
+      - DB_CLIENT_CERT
+      - DB_CLIENT_KEY
     depends_on:
       cockroachdb:
         condition: service_healthy

--- a/scripts/init.sql
+++ b/scripts/init.sql
@@ -1,0 +1,4 @@
+/* Initializes empty arrow database with svc_storage user, only on first database run */
+CREATE DATABASE arrow;
+CREATE USER svc_storage;
+GRANT ALL PRIVILEGES ON DATABASE arrow TO svc_storage;

--- a/server/src/common.rs
+++ b/server/src/common.rs
@@ -30,6 +30,8 @@ pub struct Config {
     #[serde(default)]
     pub use_tls: bool,
     pub db_ca_cert: String,
+    pub db_client_cert: Option<String>,
+    pub db_client_key: Option<String>,
 }
 
 /// Crate Errors


### PR DESCRIPTION
 * Feat: Gets rid of password hassle (for dev environments)
 * Feat: This makes cockroachdb initialization more automated, since we can now generate everything on first start
 * Fix: init container tried to bind ports that it didn't need
 * Fix: cockroachdb no longer complains about 127.0.0.1, since it advertises based on docker service host name now

NOTE: You might have to remove your cockroachdb-ssl volume when upgrading.