### PR TITLE
feat(vertiport): add grpc and psql resources

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1591,7 +1591,7 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "svc-storage"
-version = "0.6.0-develop.0"
+version = "0.7.0-develop.0"
 dependencies = [
  "anyhow",
  "cargo-husky",
@@ -1630,7 +1630,7 @@ dependencies = [
 
 [[package]]
 name = "svc-storage-client-grpc"
-version = "0.6.0-develop.0"
+version = "0.7.0-develop.0"
 dependencies = [
  "geo-types",
  "num-derive",
@@ -1641,6 +1641,7 @@ dependencies = [
  "router",
  "tokio",
  "tonic",
+ "uuid",
 ]
 
 [[package]]

--- a/client-grpc/Cargo.toml
+++ b/client-grpc/Cargo.toml
@@ -12,11 +12,12 @@ version     = "0.7.0-develop.0"
 geo-types     = "0.7"
 num-derive    = "0.3"
 num-traits    = "0.2"
-ordered-float = "3.3.0"
+ordered-float = "3.3"
 prost         = "0.11"
-prost-types   = "0.11.1"
+prost-types   = "0.11"
 router        = { git = "https://github.com/Arrow-air/lib-router.git", branch = "develop" }
-tonic         = "0.8.1"
+tonic         = "0.8"
+uuid          = { version = "1.2", features = ["v4"] }
 
 [dev-dependencies]
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }

--- a/client-grpc/src/grpc.vertiport.rs
+++ b/client-grpc/src/grpc.vertiport.rs
@@ -13,14 +13,24 @@ pub struct Vertiport {
 pub struct VertiportData {
     #[prost(string, tag="1")]
     pub description: ::prost::alloc::string::String,
-    #[prost(float, tag="2")]
-    pub latitude: f32,
-    #[prost(float, tag="3")]
-    pub longitude: f32,
+    #[prost(double, tag="2")]
+    pub latitude: f64,
+    #[prost(double, tag="3")]
+    pub longitude: f64,
     /// repeated string engineers = 5;
     /// uint32 elevation = 7;
     #[prost(string, optional, tag="4")]
     pub schedule: ::core::option::Option<::prost::alloc::string::String>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct UpdateVertiport {
+    /// id UUID v4
+    #[prost(string, tag="1")]
+    pub id: ::prost::alloc::string::String,
+    #[prost(message, optional, tag="2")]
+    pub data: ::core::option::Option<VertiportData>,
+    #[prost(message, optional, tag="3")]
+    pub mask: ::core::option::Option<::prost_types::FieldMask>,
 }
 /// Vertiports
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -158,7 +168,7 @@ pub mod vertiport_rpc_client {
         }
         pub async fn update_vertiport(
             &mut self,
-            request: impl tonic::IntoRequest<super::Vertiport>,
+            request: impl tonic::IntoRequest<super::UpdateVertiport>,
         ) -> Result<tonic::Response<super::Vertiport>, tonic::Status> {
             self.inner
                 .ready()

--- a/proto/svc-storage-grpc-vertiport.proto
+++ b/proto/svc-storage-grpc-vertiport.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 package grpc.vertiport;
 
 import "google/protobuf/empty.proto";
+import "google/protobuf/field_mask.proto";
 import "svc-storage-grpc.proto";
 
 //VertiportRpc service
@@ -9,7 +10,7 @@ service VertiportRpc {
     rpc vertiports(grpc.SearchFilter) returns (Vertiports);
     rpc vertiport_by_id(grpc.Id) returns (Vertiport);
     rpc insert_vertiport(VertiportData) returns (Vertiport);
-    rpc update_vertiport(Vertiport) returns (Vertiport);
+    rpc update_vertiport(UpdateVertiport) returns (Vertiport);
     rpc delete_vertiport(grpc.Id) returns (google.protobuf.Empty);
 }
 
@@ -23,12 +24,20 @@ message Vertiport {
 //VertiportData
 message VertiportData {
     string description = 1;
-    float latitude = 2;
-    float longitude = 3;
+    double latitude = 2;
+    double longitude = 3;
     optional string schedule = 4;
     //repeated string engineers = 5;
     //uint32 elevation = 7;
 }
+
+message UpdateVertiport {
+    // id UUID v4
+    string id = 1;
+    VertiportData data = 2;
+    google.protobuf.FieldMask mask = 3;
+}
+
 //Vertiports
 message Vertiports {
     repeated Vertiport vertiports = 1;

--- a/server/src/memdb/mod.rs
+++ b/server/src/memdb/mod.rs
@@ -52,8 +52,8 @@ async fn generate_sample_vertiports() {
                 id: node.uid.to_string(),
                 data: Some(VertiportData {
                     description: "Vertiport ".to_string() + &node.uid,
-                    latitude: node.location.latitude.into_inner(),
-                    longitude: node.location.longitude.into_inner(),
+                    latitude: node.location.latitude.into_inner().into(),
+                    longitude: node.location.longitude.into_inner().into(),
                     schedule: Some(CAL_WORKDAYS_8AM_6PM.to_string()),
                 }),
             },

--- a/server/src/postgres/mod.rs
+++ b/server/src/postgres/mod.rs
@@ -4,7 +4,7 @@
 pub mod macros;
 
 use crate::common::Config;
-use crate::resources::{flight_plan, vertipad};
+use crate::resources::{flight_plan, vertipad, vertiport};
 use anyhow::Error;
 use deadpool_postgres::{
     tokio_postgres::NoTls, ConfigError, ManagerConfig, Pool, PoolError, RecyclingMethod, Runtime,
@@ -146,6 +146,7 @@ impl fmt::Debug for PostgresPool {
 pub async fn create_db(pool: &Pool) -> Result<(), ArrErr> {
     psql_info!("Creating database tables.");
     //Create our tables (in the correct order)
+    vertiport::init_table(pool).await?;
     vertipad::init_table(pool).await?;
     flight_plan::init_table(pool).await
 }
@@ -154,7 +155,8 @@ pub async fn drop_db(pool: &Pool) -> Result<(), ArrErr> {
     psql_warn!("Dropping database tables.");
     // Drop our tables (in the correct order)
     flight_plan::drop_table(pool).await?;
-    vertipad::drop_table(pool).await
+    vertipad::drop_table(pool).await?;
+    vertiport::drop_table(pool).await
 }
 
 pub async fn recreate_db(pool: &Pool) -> Result<(), ArrErr> {

--- a/server/src/resources/vertipad/grpc.rs
+++ b/server/src/resources/vertipad/grpc.rs
@@ -211,11 +211,15 @@ impl VertipadRpc for VertipadImpl {
     /// let updated_vertipad = match vertipad_client.update_vertipad(tonic::Request::new(UpdateVertipad {
     ///     id: "54acfe06-dd9b-42e8-8cb4-12a2fb2fa693"
     ///     data: Some(VertipadData {
-    ///         first_name: "John",
-    ///         last_name: "Doe",
+    ///         description: format!("San Francisco's first"),
+    ///         latitude: 37.7749,
+    ///         longitude: -122.4194,
+    ///         enabled: true,
+    ///         occupied: false,
+    ///         schedule: Some(CAL_WORKDAYS_8AM_6PM.to_string()),
     ///     }),
     ///     mask: Some(FieldMask {
-    ///         paths: vec!["first_name".to_string()]
+    ///         paths: vec!["description".to_string()]
     ///     })
     /// }))
     /// .await

--- a/server/src/resources/vertiport/grpc.rs
+++ b/server/src/resources/vertiport/grpc.rs
@@ -5,13 +5,21 @@ mod grpc_server {
     tonic::include_proto!("grpc.vertiport");
 }
 
-pub use grpc_server::vertiport_rpc_server::{VertiportRpc, VertiportRpcServer};
-pub use grpc_server::{Vertiport, VertiportData, Vertiports};
-
-use crate::common::{Id, SearchFilter};
+use super::VertiportPsql;
+use crate::get_psql_pool;
+use crate::grpc::*;
+use crate::grpc_error;
+use crate::memdb::MEMDB_LOG_TARGET;
 use crate::memdb::VERTIPORTS;
-use tonic::{Request, Response, Status};
+use crate::memdb_info;
 use uuid::Uuid;
+
+pub use grpc_server::vertiport_rpc_server::{VertiportRpc, VertiportRpcServer};
+pub use grpc_server::{UpdateVertiport, Vertiport, VertiportData, Vertiports};
+
+use postgres_types::ToSql;
+use std::collections::HashMap;
+use tonic::{Code, Request, Response, Status};
 
 ///Implementation of gRPC endpoints
 #[derive(Debug, Default, Copy, Clone)]
@@ -19,61 +27,278 @@ pub struct VertiportImpl {}
 
 #[tonic::async_trait]
 impl VertiportRpc for VertiportImpl {
-    ///vertiport_by_id // TODO implement. Currently returns arbitrary value
+    /// Takes an UUID string (vertiport_id) to get the matching database record.
+    ///
+    /// # Arguments
+    /// * self - The VertiportRpc struct
+    /// * request - Request<Id> GRPC request
+    ///
+    /// # Returns
+    /// * Result Vertiport object or Status `not_found` if there was no vertiport found for the given Id
+    ///
+    /// # Example
+    /// ```
+    /// use svc_storage_client_grpc::client::vertiport_rpc_client::VertiportRpcClient;
+    /// use svc_storage_client_grpc::client::Id;
+    ///
+    /// let mut vertiport_client = VertiportRpcClient::connect(grpc_endpoint.clone()).await.unwrap();
+    /// let result = match vertiport_client.vertiport_by_id(tonic::Request::new(Id {
+    ///     id: "54acfe06-dd9b-42e8-8cb4-12a2fb2fa693"
+    /// }))
+    /// .await
+    /// {
+    ///    Ok(vertiport) => vertiport.into_inner(),
+    ///    Err(e) => panic!("Something went wrong retrieving the vertiport: {}", e),
+    /// };
+    /// ```
     async fn vertiport_by_id(&self, request: Request<Id>) -> Result<Response<Vertiport>, Status> {
         let id = request.into_inner().id;
-        match VERTIPORTS.lock().await.get(&id) {
-            Some(vertiport) => Ok(Response::new(vertiport.clone())),
-            _ => Err(Status::not_found("Not found")),
+        if let Some(vertiport) = VERTIPORTS.lock().await.get(&id) {
+            memdb_info!("Found entry for Vertiport. uuid: {}", id);
+            Ok(Response::new(vertiport.clone()))
+        } else {
+            let pool = get_psql_pool();
+            let data = VertiportPsql::new(&pool, Uuid::try_parse(&id).unwrap()).await;
+            match data {
+                Ok(vertiport) => Ok(Response::new(Vertiport {
+                    id,
+                    data: Some(vertiport.into()),
+                })),
+                Err(_) => Err(Status::not_found("Not found")),
+            }
         }
     }
 
-    ///vertiports // TODO implement. Currently returns arbitrary value
+    /// Takes a `SearchFilter` object to search the database with the provided values.
+    ///
+    /// This method supports paged results. When the `search_field` and `search_value` are empty, no filters will be applied.
+    ///
+    /// # Arguments
+    /// * self  - The VertiportRpc struct
+    /// * request - Request<SearchFilter> GRPC request
+    ///
+    /// # Returns
+    /// * Result Vertiports object or Status `Code::Internal` if there was an error in the search query
+    ///
+    /// # Example
+    /// ```
+    /// use svc_storage_client_grpc::client::vertiport_rpc_client::VertiportRpcClient;
+    /// use svc_storage_client_grpc::client::SearchFilter;
+    ///
+    /// let mut vertiport_client = VertiportRpcClient::connect(grpc_endpoint.clone()).await.unwrap();
+    /// let result = match vertiport_client.vertiports(tonic::Request::new(SearchFilter {
+    ///     search_field: "auth_method",
+    ///     search_value: "1",
+    ///     page_number: 1,
+    ///     results_per_page: 20
+    /// }))
+    /// .await
+    /// {
+    ///    Ok(vertiports) => vertiport.into_inner(),
+    ///    Err(e) => panic!("Something went wrong creating retrieving vertiports: {}", e),
+    /// };
+    /// ```
     async fn vertiports(
         &self,
-        _request: Request<SearchFilter>,
+        request: Request<SearchFilter>,
     ) -> Result<Response<Vertiports>, Status> {
-        let response = Vertiports {
-            vertiports: VERTIPORTS.lock().await.values().cloned().collect::<_>(),
-        };
-        Ok(Response::new(response))
+        let filter = request.into_inner();
+        let mut filter_hash = HashMap::<String, String>::new();
+        filter_hash.insert("column".to_string(), filter.search_field);
+        filter_hash.insert("value".to_string(), filter.search_value);
+
+        let pool = get_psql_pool();
+        match super::psql::search(&pool, &filter_hash).await {
+            Ok(vertiports) => Ok(Response::new(vertiports.into())),
+            Err(e) => Err(Status::new(Code::Internal, e.to_string())),
+        }
     }
 
+    /// Takes an `VertiportData` object to create a new vertiport with the provided data.
+    ///
+    /// A new UUID will be generated by the database and returned as `id` as part of the returned `Vertiport` object.
+    ///
+    /// # Arguments
+    /// * self - The VertiportRpc struct
+    /// * request - Request<VertiportData> GRPC request
+    ///
+    /// # Returns
+    /// Result Vertiport object or Status `Code::Internal` if the vertiport could not be inserted
+    ///
+    /// # Example
+    /// ```
+    /// use svc_storage_client_grpc::client::vertiport_rpc_client::{VertiportRpcClient, VertiportData};
+    /// const CAL_WORKDAYS_8AM_6PM: &str = "\
+    /// DTSTART:20221020T180000Z;DURATION:PT14H
+    /// RRULE:FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR
+    /// DTSTART:20221022T000000Z;DURATION:PT24H
+    /// RRULE:FREQ=WEEKLY;BYDAY=SA,SU";
+    ///
+    /// let mut vertiport_client = VertiportRpcClient::connect(grpc_endpoint.clone()).await.unwrap();
+    /// let result = match vertiport_client.insert_vertiport(tonic::Request::new(VertiportData {
+    ///     description: format!("First vertiport built in San Francisco"),
+    ///     latitude: 37.7749,
+    ///     longitude: -122.4194,
+    ///     schedule: Some(CAL_WORKDAYS_8AM_6PM.to_string()),
+    /// }))
+    /// .await
+    /// {
+    ///    Ok(vertiport) => vertiport.into_inner(),
+    ///    Err(e) => panic!("Something went wrong creating the vertiport: {}", e),
+    /// };
+    /// ```
     async fn insert_vertiport(
         &self,
         request: Request<VertiportData>,
     ) -> Result<Response<Vertiport>, Status> {
         let mut vertiports = VERTIPORTS.lock().await;
         let data = request.into_inner();
-        let vertiport = Vertiport {
-            id: Uuid::new_v4().to_string(),
-            data: Some(data),
-        };
-        vertiports.insert(vertiport.id.clone(), vertiport.clone());
-        Ok(Response::new(vertiport))
-    }
+        let pool = get_psql_pool();
 
-    async fn update_vertiport(
-        &self,
-        request: Request<Vertiport>,
-    ) -> Result<Response<Vertiport>, Status> {
-        let vertiport = request.into_inner();
-        let id = vertiport.id;
-        match VERTIPORTS.lock().await.get_mut(&id) {
-            Some(vertiport) => {
-                vertiport.data = Some(VertiportData {
-                    ..vertiport.data.clone().unwrap()
-                });
-                println!("Vertiport: {:?}", vertiport);
-                Ok(Response::new(vertiport.clone()))
+        let mut vertiport_data = HashMap::<&str, &(dyn ToSql + Sync)>::new();
+        vertiport_data.insert("description", &data.description);
+        vertiport_data.insert("longitude", &data.longitude);
+        vertiport_data.insert("latitude", &data.latitude);
+
+        match super::psql::create(&pool, vertiport_data.clone()).await {
+            Ok(vertiport) => {
+                let id = vertiport.id.to_string();
+                let vertiport = Vertiport {
+                    id: id.clone(),
+                    data: Some(data.clone()),
+                };
+                vertiports.insert(id, vertiport.clone());
+                Ok(Response::new(vertiport))
             }
-            _ => Err(Status::not_found("Not found")),
+            Err(e) => Err(Status::new(Code::Internal, e.to_string())),
         }
     }
 
+    /// Takes an `UpdateVertiport` object to store new data to the database
+    ///
+    /// A field mask can be provided to restrict updates to specific fields.
+    /// Returns the updated `Vertiport` on success.
+    ///
+    /// # Arguments
+    /// * self  - The VertiportRpc struct
+    /// * request - Request<UpdateVertiport> GRPC request
+    ///
+    /// # Returns
+    /// * Result Vertiport object or:
+    ///   - Status `not_found` if there was no vertiport found for the given Id
+    ///   - Status `cancelled` if no data was provided in the UpdateVertiport object
+    ///   - Status `Code::Internal` if the vertiport could not be updated
+    ///
+    /// # Example
+    /// ```
+    /// use svc_storage_client_grpc::client::vertiport_rpc_client::{VertiportRpcClient, UpdateVertiport};
+    ///
+    /// let mut vertiport_client = VertiportRpcClient::connect(grpc_endpoint.clone()).await.unwrap();
+    /// let updated_vertiport = match vertiport_client.update_vertiport(tonic::Request::new(UpdateVertiport {
+    ///     id: "54acfe06-dd9b-42e8-8cb4-12a2fb2fa693"
+    ///     data: Some(VertiportData {
+    ///         description: format!("San Francisco's first"),
+    ///         latitude: 37.7749,
+    ///         longitude: -122.4194,
+    ///         schedule: Some(CAL_WORKDAYS_8AM_6PM.to_string()),
+    ///     }),
+    ///     mask: Some(FieldMask {
+    ///         paths: vec!["description".to_string()]
+    ///     })
+    /// }))
+    /// .await
+    /// {
+    ///    Ok(vertiport) => vertiport.into_inner(),
+    ///    Err(e) => panic!("Something went wrong updating the vertiport info: {}", e),
+    /// };
+    /// ```
+    async fn update_vertiport(
+        &self,
+        request: Request<UpdateVertiport>,
+    ) -> Result<Response<Vertiport>, Status> {
+        let vertiport_req = request.into_inner();
+        let id = match Uuid::try_parse(&vertiport_req.id) {
+            Ok(id) => id,
+            Err(_e) => Uuid::new_v4(),
+        };
+
+        let data = match vertiport_req.data {
+            Some(data) => data,
+            None => {
+                grpc_error!("No data provided for update vertiport with id: {}", id);
+                return Err(Status::cancelled("No data found for update vertiport"));
+            }
+        };
+
+        let pool = get_psql_pool();
+        let vertiport = match VertiportPsql::new(&pool, id).await {
+            Ok(vertiport) => vertiport,
+            Err(e) => {
+                grpc_error!("Could not find vertiport with id: {}. {}", id, e);
+                return Err(Status::not_found("Unknown vertiport id"));
+            }
+        };
+
+        let mut vertiport_data = HashMap::<&str, &(dyn ToSql + Sync)>::new();
+        vertiport_data.insert("description", &data.description);
+        vertiport_data.insert("longitude", &data.longitude);
+        vertiport_data.insert("latitude", &data.latitude);
+
+        match vertiport.update(vertiport_data.clone()).await {
+            Ok(vertiport_data) => {
+                let result = Vertiport {
+                    id: id.to_string(),
+                    data: Some(vertiport_data.into()),
+                };
+                // Update cache
+                let mut vertiports = VERTIPORTS.lock().await;
+                vertiports.insert(id.to_string(), result.clone());
+
+                Ok(Response::new(result.clone()))
+            }
+            Err(e) => Err(Status::new(Code::Internal, e.to_string())),
+        }
+    }
+
+    /// Takes an UUID string (vertiport_id) to set the matching vertiport record a deleted in the database.
+    ///
+    /// The `deleted_at` column will be set to the current timestamp, indicating that the Vertiport is not active anymore.
+    ///
+    /// # Arguments
+    /// * self  - The VertiportRpc struct
+    /// * request - Request<Id> GRPC request
+    ///
+    /// # Returns
+    /// * Result empty or Status `Code::Internal` if the vertiport could not be deleted
+    ///
+    /// # Example
+    /// ```
+    /// use svc_storage_client_grpc::client::vertiport_rpc_client::VertiportRpcClient;
+    /// use svc_storage_client_grpc::client::Id;
+    ///
+    /// let mut vertiport_client = VertiportRpcClient::connect(grpc_endpoint.clone()).await.unwrap();
+    /// let result = match vertiport_client.delete_vertiport(tonic::Request::new(Id {
+    ///     id: "54acfe06-dd9b-42e8-8cb4-12a2fb2fa693"
+    /// }))
+    /// .await
+    /// {
+    ///    Ok(vertiport) => vertiport.into_inner(),
+    ///    Err(e) => panic!("Something went wrong deleting the vertiport: {}", e),
+    /// };
+    /// ```
     async fn delete_vertiport(&self, request: Request<Id>) -> Result<Response<()>, Status> {
-        let mut vertiports = VERTIPORTS.lock().await;
-        vertiports.remove(&request.into_inner().id);
-        Ok(Response::new(()))
+        let id = request.into_inner().id;
+        let pool = get_psql_pool();
+        let vertiport = VertiportPsql::new(&pool, Uuid::try_parse(&id).unwrap()).await?;
+
+        match vertiport.delete().await {
+            Ok(_) => {
+                // Update cache
+                let mut vertiports = VERTIPORTS.lock().await;
+                vertiports.remove(&id);
+                Ok(Response::new(()))
+            }
+            Err(e) => Err(Status::new(Code::Internal, e.to_string())),
+        }
     }
 }

--- a/server/src/resources/vertiport/mod.rs
+++ b/server/src/resources/vertiport/mod.rs
@@ -2,5 +2,49 @@
 
 // Expose grpc resources
 mod grpc;
+mod psql;
 
 pub use grpc::{Vertiport, VertiportData, VertiportImpl, VertiportRpcServer, Vertiports};
+pub use psql::{create, delete, drop_table, init_table, search, VertiportPsql};
+
+use tokio_postgres::row::Row;
+use uuid::Uuid;
+
+use crate::{grpc::GRPC_LOG_TARGET, grpc_debug};
+
+impl From<Vec<Row>> for Vertiports {
+    fn from(vertiports: Vec<Row>) -> Self {
+        grpc_debug!("Converting Vec<Row> to Vertiports: {:?}", vertiports);
+        let mut res: Vec<Vertiport> = Vec::with_capacity(vertiports.len());
+        let iter = vertiports.into_iter();
+        for vertiport in iter {
+            let vertiport_id: Uuid = vertiport.get("vertiport_id");
+            let vertiport = Vertiport {
+                id: vertiport_id.to_string(),
+                data: Some(vertiport.into()),
+            };
+            res.push(vertiport);
+        }
+        Vertiports { vertiports: res }
+    }
+}
+
+/// Converting a postgresql Row object into a GRPC VertiportData object
+impl From<Row> for VertiportData {
+    fn from(vertiport: Row) -> Self {
+        let schedule: Option<String> = vertiport.get("schedule");
+        VertiportData {
+            description: vertiport.get("description"),
+            latitude: vertiport.get("latitude"),
+            longitude: vertiport.get("longitude"),
+            schedule,
+        }
+    }
+}
+
+/// Converting the VertiportPsql.data (Row) object into a GRPC VertiportData object
+impl From<VertiportPsql> for VertiportData {
+    fn from(vertiport: VertiportPsql) -> Self {
+        vertiport.data.into()
+    }
+}


### PR DESCRIPTION
### Main changes
 - Added grpc implementations for `vertipad` resource
 - Added table and SQL queries for `vertipad` resource 
 - Added vertiport generation for `grpc` example
 
 closes: https://github.com/Arrow-air/svc-storage/issues/12