### PR TITLE
feat: add path field to flight plan

### DIFF
--- a/docs/sdd.md
+++ b/docs/sdd.md
@@ -650,7 +650,7 @@ erDiagram
         uuid pilot_id FK
         uuid vehicle_id FK
         json cargo_weight_grams
-        integer flight_distance_meters
+        geometry path "LINESTRING"
         text weather_conditions "Optional"
         uuid departure_vertipad_id FK
         uuid destination_vertipad_id FK

--- a/proto/svc-storage-grpc-flight_plan-service.proto
+++ b/proto/svc-storage-grpc-flight_plan-service.proto
@@ -68,7 +68,7 @@ service RpcService {
     //         vehicle_id,
     //         pilot_id,
     //         cargo_weight_grams: vec![20],
-    //         flight_distance_meters: 6000,
+    //         path: GeoLineString { points: vec![] },
     //         weather_conditions: Some("Cloudy, low wind".to_owned()),
     //         departure_vertipad_id,
     //         departure_vertiport_id: None,

--- a/proto/svc-storage-grpc-flight_plan.proto
+++ b/proto/svc-storage-grpc-flight_plan.proto
@@ -70,8 +70,8 @@ message Data {
     string vehicle_id = 2;
     // cargo weight in grams per package
     repeated uint32 cargo_weight_grams = 3;
-    // flight_distance in meters
-    uint32 flight_distance_meters = 4;
+    // the path of the flight
+    grpc.GeoLineString path = 4;
     // weather_conditions
     optional string weather_conditions = 5;
     // departure_vertiport_id UUID v4, only listed for get results, not needed for creation (known through pad_id)

--- a/server/src/postgres/postgis.rs
+++ b/server/src/postgres/postgis.rs
@@ -106,6 +106,7 @@ impl From<LineString> for GeoLineString {
         GeoLineString { points }
     }
 }
+
 impl From<Polygon> for GeoPolygon {
     fn from(field: Polygon) -> Self {
         let mut polygon: Self = Self {


### PR DESCRIPTION
Replaces 'flight_distance_meters' with a 'path' field.

Distance can be calculated from the length of the LineString, so we shouldn't have to update a separate distance field when the path is updated.

The path's points should eventually be PointZ type to account for altitude, which we'll include in R4.

The 'path' will be delivered to the vehicle along with other flight plan details for autonomous waypoint following.

