### PR TITLE
Fix missing create table statements

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ git add client-grpc/
 - client-grpc/Cargo.toml
   * Add your resource to the `all_resources` feature.
   * Create a feature for your new resource with a `any_resource` dependency.
-- client-grpc/tests/resources/\<your ne resource name\>.rs
+- client-grpc/tests/resources/\<your new resource name\>.rs
   * Update the `assert_eq` tests for the correct data fields.
 - client-grpc/tests/integration_test.rs
   * Add a scenario for the new resource, testing all service functions.

--- a/server/src/postgres/init.rs
+++ b/server/src/postgres/init.rs
@@ -5,10 +5,7 @@ use std::collections::HashMap;
 use super::linked_resource::PsqlType as LinkedPsqlType;
 use super::simple_resource::PsqlType as SimplePsqlType;
 use super::{get_psql_pool, ArrErr, PsqlFieldType};
-use crate::grpc::server::{
-    adsb, flight_plan, flight_plan_parcel, group, itinerary, itinerary_flight_plan, parcel,
-    parcel_scan, pilot, scanner, user, user_group, vehicle, vertipad, vertiport,
-};
+use crate::grpc::server::*;
 use crate::resources::{
     base::FieldDefinition,
     base::{Resource, ResourceObject},
@@ -22,8 +19,11 @@ pub async fn create_db() -> Result<(), ArrErr> {
     ResourceObject::<user::Data>::init_table().await?;
     ResourceObject::<user_group::Data>::init_table().await?;
     ResourceObject::<vertiport::Data>::init_table().await?;
+    ResourceObject::<vertiport_group::Data>::init_table().await?;
     ResourceObject::<vertipad::Data>::init_table().await?;
+    ResourceObject::<vertipad_group::Data>::init_table().await?;
     ResourceObject::<vehicle::Data>::init_table().await?;
+    ResourceObject::<vehicle_group::Data>::init_table().await?;
     ResourceObject::<pilot::Data>::init_table().await?;
     ResourceObject::<adsb::Data>::init_table().await?;
     ResourceObject::<flight_plan::Data>::init_table().await?;
@@ -50,8 +50,11 @@ pub async fn drop_db() -> Result<(), ArrErr> {
     ResourceObject::<flight_plan::Data>::drop_table().await?;
     ResourceObject::<adsb::Data>::drop_table().await?;
     ResourceObject::<pilot::Data>::drop_table().await?;
+    ResourceObject::<vehicle_group::Data>::drop_table().await?;
     ResourceObject::<vehicle::Data>::drop_table().await?;
+    ResourceObject::<vertipad_group::Data>::drop_table().await?;
     ResourceObject::<vertipad::Data>::drop_table().await?;
+    ResourceObject::<vertiport_group::Data>::drop_table().await?;
     ResourceObject::<vertiport::Data>::drop_table().await?;
     ResourceObject::<user_group::Data>::drop_table().await?;
     ResourceObject::<user::Data>::drop_table().await?;


### PR DESCRIPTION
Fixes the missing tables for newly added asset groups.
Also fixes the integration test for vehicles after the introduction of `hangar_id` and `hangar_bay_id` which must be a valid (existing) UUID.