### PR TITLE
fix(client-grpc): fix rest references for geo types

### DIFF
--- a/.cspell.project-words.txt
+++ b/.cspell.project-words.txt
@@ -112,3 +112,4 @@ Linkeds
 hexstr
 Rnever
 Rwaiting
+timeslots

--- a/client-grpc/build.rs
+++ b/client-grpc/build.rs
@@ -8,5 +8,17 @@ include!("../includes/build.rs");
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     build_proto("../out/grpc/client", false, true)?;
 
+    let cur_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
+    let proto_dir = "../proto";
+
+    let builder = get_grpc_builder_config(&format!("{}/{}", cur_dir, "../out/grpc/client/"));
+    builder
+        .type_attribute("GeoPointZ", "#[derive(ToSchema, IntoParams)]")
+        .type_attribute("GeoPolygonZ", "#[derive(ToSchema, IntoParams)]")
+        .type_attribute("GeoLineStringZ", "#[derive(ToSchema, IntoParams)]")
+        .build_server(false)
+        .build_client(false)
+        .compile(&[get_file(proto_dir, "geo_types".to_owned())], &[proto_dir])?;
+
     Ok(())
 }

--- a/includes/build.rs
+++ b/includes/build.rs
@@ -123,6 +123,9 @@ fn add_utoipa_attributes(
 ) -> tonic_build::Builder {
     // Add utoipa derive macro's for client exposed structs
     builder
+        .extern_path(".grpc.geo_types.GeoPointZ", "GeoPointZ")
+        .extern_path(".grpc.geo_types.GeoLineStringZ", "GeoLineStringZ")
+        .extern_path(".grpc.geo_types.GeoPolygonZ", "GeoPolygonZ")
         // Add schema type for timestamp fields
         .field_attribute(
             "created_at",
@@ -211,7 +214,4 @@ fn add_utoipa_attributes(
             "Response",
             format!("#[schema(as = {}::Response)]", resource_type),
         )
-        .type_attribute("GeoPointZ", "#[derive(ToSchema, IntoParams)]")
-        .type_attribute("GeoPolygonZ", "#[derive(ToSchema, IntoParams)]")
-        .type_attribute("GeoLineStringZ", "#[derive(ToSchema, IntoParams)]")
 }


### PR DESCRIPTION
This fixes the Geo Type paths so that they will be usable in client libraries.

Without this fix, the Geo Types would be referenced with the `super.geo_types` prefix. 
By building the `grpc.geo_types.rs` file first, and then telling all other resource files to use the Geo Types as is (no path prefix), we can now reuse the structs in our other services' rest API's

This will fix the currently failing openapi validation test in `svc-assets`